### PR TITLE
feat: basic time entries

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -5,6 +5,11 @@
   text-align: center;
 }
 
+main {
+  display: grid;
+  row-gap: 5rem;
+}
+
 .time-display {
   display: flex;
   flex-direction: row;
@@ -35,5 +40,6 @@ button {
 
 .timer {
   display: grid;
-  row-gap: 4rem;
+  row-gap: 2rem;
+  place-content: center;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,9 +5,9 @@ import { Timer } from "./components/Timer";
 import { NotificationsPermissionBtn } from "./components/NotificationsPermissionBtn";
 
 function App() {
-  const [totalTime, setTotalTime] = useState<number>(
-    () => Number(window.localStorage.getItem("totalTime")) ?? 0
-  );
+  const [timeEntries, setTimeEntries] = useState<
+    Array<{ start: number; end: number; text: string }>
+  >(() => JSON.parse(window.localStorage.getItem("entries") ?? "[]"));
   const [
     shouldRequestNotificationsPermission,
     setShouldRequestNotificationsPermission,
@@ -15,11 +15,19 @@ function App() {
     // if permission is not default then persimion is granted, denied, or Notifications API is not supported
     () => window.Notification?.permission === "default"
   );
+  const totalTime =
+    timeEntries.length > 0
+      ? (timeEntries[timeEntries.length - 1].end - timeEntries[0].start) / 1000
+      : 0;
 
-  const updateTotalTime = (time: number) => {
-    const nextValue = totalTime + time;
-    window.localStorage.setItem("totalTime", nextValue.toString());
-    setTotalTime(nextValue);
+  const updateTimeEntries = (entry: {
+    start: number;
+    end: number;
+    text: string;
+  }) => {
+    const nextValue = timeEntries.concat(entry);
+    window.localStorage.setItem("entries", JSON.stringify(nextValue));
+    setTimeEntries(nextValue);
   };
 
   const requestPermission = () => {
@@ -58,7 +66,7 @@ function App() {
       {shouldRequestNotificationsPermission ? (
         <NotificationsPermissionBtn handleClick={requestPermission} />
       ) : null}
-      <Timer totalTime={totalTime} updateTotalTime={updateTotalTime} />
+      <Timer totalTime={totalTime} updateTimeEntries={updateTimeEntries} />
     </>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import "./App.css";
 import { Timer } from "./components/Timer";
 import { NotificationsPermissionBtn } from "./components/NotificationsPermissionBtn";
+import { TimeEntries } from "./components/TimeEntries";
 
 function App() {
   const [timeEntries, setTimeEntries] = useState<
@@ -67,6 +68,7 @@ function App() {
         <NotificationsPermissionBtn handleClick={requestPermission} />
       ) : null}
       <Timer totalTime={totalTime} updateTimeEntries={updateTimeEntries} />
+      <TimeEntries entries={timeEntries} />
     </>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { Timer } from "./components/Timer";
 import { NotificationsPermissionBtn } from "./components/NotificationsPermissionBtn";
 import { TimeEntries } from "./components/TimeEntries";
 import { getTodaysTotalTime } from "./helpers";
+import { TotalsDisplay } from "./components/Timer/TotalsDisplay";
 
 function App() {
   const [timeEntries, setTimeEntries] = useState<
@@ -61,13 +62,18 @@ function App() {
   }, []);
 
   return (
-    <>
-      {shouldRequestNotificationsPermission ? (
-        <NotificationsPermissionBtn handleClick={requestPermission} />
-      ) : null}
-      <Timer totalTime={totalTime} updateTimeEntries={updateTimeEntries} />
-      <TimeEntries entries={timeEntries} />
-    </>
+    <main>
+      <section>
+        {shouldRequestNotificationsPermission ? (
+          <NotificationsPermissionBtn handleClick={requestPermission} />
+        ) : null}
+        <Timer updateTimeEntries={updateTimeEntries} />
+      </section>
+      <section>
+        <TotalsDisplay totalTime={totalTime} />
+        <TimeEntries entries={timeEntries} />
+      </section>
+    </main>
   );
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import "./App.css";
 import { Timer } from "./components/Timer";
 import { NotificationsPermissionBtn } from "./components/NotificationsPermissionBtn";
 import { TimeEntries } from "./components/TimeEntries";
+import { getTodaysTotalTime } from "./helpers";
 
 function App() {
   const [timeEntries, setTimeEntries] = useState<
@@ -16,10 +17,7 @@ function App() {
     // if permission is not default then persimion is granted, denied, or Notifications API is not supported
     () => window.Notification?.permission === "default"
   );
-  const totalTime =
-    timeEntries.length > 0
-      ? (timeEntries[timeEntries.length - 1].end - timeEntries[0].start) / 1000
-      : 0;
+  const totalTime = getTodaysTotalTime(timeEntries);
 
   const updateTimeEntries = (entry: {
     start: number;

--- a/src/components/TimeEntries/TimeEntries.tsx
+++ b/src/components/TimeEntries/TimeEntries.tsx
@@ -1,0 +1,15 @@
+import { TimeEntry } from "./TimeEntry";
+
+interface Props {
+  entries: Array<{ start: number; end: number; text: string }>;
+}
+
+export function TimeEntries({ entries }: Props) {
+  return (
+    <div>
+      {entries.map((entry) => {
+        return <TimeEntry entry={entry} />;
+      })}
+    </div>
+  );
+}

--- a/src/components/TimeEntries/TimeEntries.tsx
+++ b/src/components/TimeEntries/TimeEntries.tsx
@@ -1,3 +1,4 @@
+import { getTodaysEarliestEntryIndex } from "../../helpers";
 import { TimeEntry } from "./TimeEntry";
 
 interface Props {
@@ -5,9 +6,19 @@ interface Props {
 }
 
 export function TimeEntries({ entries }: Props) {
+  const idx = getTodaysEarliestEntryIndex(entries);
+  const todaysEntries = entries.slice(idx).reverse();
+
   return (
-    <div style={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)" }}>
-      {entries.map((entry) => {
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "repeat(4, 1fr)",
+        maxHeight: "318px",
+        overflow: "auto",
+      }}
+    >
+      {todaysEntries.map((entry) => {
         return <TimeEntry entry={entry} />;
       })}
     </div>

--- a/src/components/TimeEntries/TimeEntries.tsx
+++ b/src/components/TimeEntries/TimeEntries.tsx
@@ -6,7 +6,7 @@ interface Props {
 
 export function TimeEntries({ entries }: Props) {
   return (
-    <div>
+    <div style={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)" }}>
       {entries.map((entry) => {
         return <TimeEntry entry={entry} />;
       })}

--- a/src/components/TimeEntries/TimeEntry.tsx
+++ b/src/components/TimeEntries/TimeEntry.tsx
@@ -45,6 +45,9 @@ export function TimeEntry({ entry }: Props) {
       <p style={{ marginBlockStart: "0", marginBlockEnd: "0" }}>
         {totalMinutes === 0 ? "" : `${totalMinutes}min`} {totalSeconds}s
       </p>
+      <p style={{ marginBlockStart: "0", marginBlockEnd: "0" }}>
+        {entry.text ? `"${entry.text}"` : ""}
+      </p>
     </div>
   );
 }

--- a/src/components/TimeEntries/TimeEntry.tsx
+++ b/src/components/TimeEntries/TimeEntry.tsx
@@ -27,16 +27,23 @@ export function TimeEntry({ entry }: Props) {
   const totalMinutes = Math.floor((entry.end - entry.start) / 1000 / 60);
   const totalSeconds = Math.floor((entry.end - entry.start) / 1000) % 60;
   return (
-    <div>
-      <p>
+    <div
+      style={{
+        border: "1px dashed gray",
+        padding: "1rem",
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      <p style={{ marginBlockStart: "0", marginBlockEnd: "0" }}>
         {dateOneFormatted}{" "}
         {dateOneFormatted !== dateTwoFormatted ? `- ${dateTwoFormatted}` : null}
       </p>
-      <p>
+      <p style={{ marginBlockStart: "0", marginBlockEnd: "0" }}>
         {timeStart} - {timeEnd}
       </p>
-      <p>
-        {totalMinutes}min {totalSeconds}s
+      <p style={{ marginBlockStart: "0", marginBlockEnd: "0" }}>
+        {totalMinutes === 0 ? "" : `${totalMinutes}min`} {totalSeconds}s
       </p>
     </div>
   );

--- a/src/components/TimeEntries/TimeEntry.tsx
+++ b/src/components/TimeEntries/TimeEntry.tsx
@@ -1,0 +1,43 @@
+interface Props {
+  entry: { start: number; end: number; text: string };
+}
+
+export function TimeEntry({ entry }: Props) {
+  const dateOne = new Date(entry.start);
+  const dateTwo = new Date(entry.end);
+  const dateOneFormatted = `${(dateOne.getMonth() + 1)
+    .toString()
+    .padStart(2, "0")} / ${dateOne.getDate().toString().padStart(2, "0")}`;
+  const dateTwoFormatted = `${(dateTwo.getMonth() + 1)
+    .toString()
+    .padStart(2, "0")} / ${dateTwo.getDate().toString().padStart(2, "0")}`;
+  const timeStart = `${(dateOne.getHours() === 12
+    ? 12
+    : dateOne.getHours() % 12
+  )
+    .toString()
+    .padStart(2, "0")}:${dateOne.getMinutes().toString().padStart(2, "0")}${
+    dateOne.getHours() >= 12 ? "pm" : "am"
+  }`;
+  const timeEnd = `${(dateTwo.getHours() === 12 ? 12 : dateTwo.getHours() % 12)
+    .toString()
+    .padStart(2, "0")}:${dateTwo.getMinutes().toString().padStart(2, "0")}${
+    dateOne.getHours() >= 12 ? "pm" : "am"
+  }`;
+  const totalMinutes = Math.floor((entry.end - entry.start) / 1000 / 60);
+  const totalSeconds = Math.floor((entry.end - entry.start) / 1000) % 60;
+  return (
+    <div>
+      <p>
+        {dateOneFormatted}{" "}
+        {dateOneFormatted !== dateTwoFormatted ? `- ${dateTwoFormatted}` : null}
+      </p>
+      <p>
+        {timeStart} - {timeEnd}
+      </p>
+      <p>
+        {totalMinutes}min {totalSeconds}s
+      </p>
+    </div>
+  );
+}

--- a/src/components/TimeEntries/index.ts
+++ b/src/components/TimeEntries/index.ts
@@ -1,0 +1,1 @@
+export * from "./TimeEntries";

--- a/src/components/Timer/Comment.tsx
+++ b/src/components/Timer/Comment.tsx
@@ -1,0 +1,26 @@
+import { useState } from "react";
+
+interface Props {
+  text: string;
+  updateTimeEntry: React.Dispatch<
+    React.SetStateAction<{ start: number; text: string }>
+  >;
+}
+
+export function Comment({ text, updateTimeEntry }: Props) {
+  const [comment, setComment] = useState<string>(text);
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setComment(e.currentTarget.value);
+  };
+  const persistComment = () => {
+    updateTimeEntry((prev) => ({ ...prev, text: comment }));
+  };
+
+  return (
+    <textarea
+      value={comment}
+      onChange={handleChange}
+      onBlur={persistComment}
+    ></textarea>
+  );
+}

--- a/src/components/Timer/Timer.tsx
+++ b/src/components/Timer/Timer.tsx
@@ -6,16 +6,25 @@ import { TotalsDisplay } from "./TotalsDisplay";
 import { notify } from "../../helpers";
 
 const DEFAULT_TIME = 2400;
+const DEFAULT_TIME_ENTRY = {
+  start: -1,
+  text: "",
+};
 
 interface Props {
   totalTime: number;
-  updateTotalTime: (time: number) => void;
+  updateTimeEntries: (timeEntry: {
+    start: number;
+    end: number;
+    text: string;
+  }) => void;
 }
 
-export function Timer({ totalTime, updateTotalTime }: Props) {
+export function Timer({ totalTime, updateTimeEntries }: Props) {
   const [status, setStatus] = useState<"on" | "paused" | "off">("off");
   const [timeSpent, setTimeSpent] = useState(0);
   const [timeBudget, setTimeBudget] = useState(DEFAULT_TIME);
+  const [partialTimeEntry, setPartialTimeEntry] = useState(DEFAULT_TIME_ENTRY);
   const workerRef = useRef<Worker | null>(null);
   const timeLeft = timeBudget - timeSpent;
 
@@ -23,6 +32,10 @@ export function Timer({ totalTime, updateTotalTime }: Props) {
     if (status === "on") return;
     workerRef.current?.postMessage({ type: "START" });
     setStatus("on");
+    setPartialTimeEntry((prev) => ({
+      ...prev,
+      start: Date.now(),
+    }));
   };
 
   const stop = () => {
@@ -31,7 +44,12 @@ export function Timer({ totalTime, updateTotalTime }: Props) {
     workerRef.current?.postMessage({ type: "STOP" });
     notify();
     setTimeSpent(0);
-    updateTotalTime(timeSpent);
+    const timeEntry = {
+      ...partialTimeEntry,
+      end: Date.now(),
+    };
+    setPartialTimeEntry(DEFAULT_TIME_ENTRY);
+    updateTimeEntries(timeEntry);
   };
 
   const pause = () => {

--- a/src/components/Timer/Timer.tsx
+++ b/src/components/Timer/Timer.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from "react";
 import { ActionButtons } from "./ActionButtons";
 import { TimeDisplay } from "./TimeDisplay";
 import { notify } from "../../helpers";
+import { Comment } from "./Comment";
 
 const DEFAULT_TIME = 2400;
 const DEFAULT_TIME_ENTRY = {
@@ -88,6 +89,11 @@ export function Timer({ updateTimeEntries }: Props) {
         />
       </div>
       <ActionButtons start={start} pause={pause} stop={stop} status={status} />
+      <Comment
+        text={partialTimeEntry.text}
+        updateTimeEntry={setPartialTimeEntry}
+        key={partialTimeEntry.text}
+      />
     </div>
   );
 }

--- a/src/components/Timer/Timer.tsx
+++ b/src/components/Timer/Timer.tsx
@@ -23,7 +23,9 @@ export function Timer({ updateTimeEntries }: Props) {
   const [status, setStatus] = useState<"on" | "paused" | "off">("off");
   const [timeSpent, setTimeSpent] = useState(0);
   const [timeBudget, setTimeBudget] = useState(DEFAULT_TIME);
-  const [partialTimeEntry, setPartialTimeEntry] = useState(DEFAULT_TIME_ENTRY);
+  const [partialTimeEntry, setPartialTimeEntry] = useState({
+    ...DEFAULT_TIME_ENTRY,
+  });
   const workerRef = useRef<Worker | null>(null);
   const timeLeft = timeBudget - timeSpent;
 
@@ -47,7 +49,7 @@ export function Timer({ updateTimeEntries }: Props) {
       ...partialTimeEntry,
       end: Date.now(),
     };
-    setPartialTimeEntry(DEFAULT_TIME_ENTRY);
+    setPartialTimeEntry({ ...DEFAULT_TIME_ENTRY });
     updateTimeEntries(timeEntry);
   };
 

--- a/src/components/Timer/Timer.tsx
+++ b/src/components/Timer/Timer.tsx
@@ -2,7 +2,6 @@ import { useEffect, useRef, useState } from "react";
 
 import { ActionButtons } from "./ActionButtons";
 import { TimeDisplay } from "./TimeDisplay";
-import { TotalsDisplay } from "./TotalsDisplay";
 import { notify } from "../../helpers";
 
 const DEFAULT_TIME = 2400;
@@ -12,7 +11,6 @@ const DEFAULT_TIME_ENTRY = {
 };
 
 interface Props {
-  totalTime: number;
   updateTimeEntries: (timeEntry: {
     start: number;
     end: number;
@@ -20,7 +18,7 @@ interface Props {
   }) => void;
 }
 
-export function Timer({ totalTime, updateTimeEntries }: Props) {
+export function Timer({ updateTimeEntries }: Props) {
   const [status, setStatus] = useState<"on" | "paused" | "off">("off");
   const [timeSpent, setTimeSpent] = useState(0);
   const [timeBudget, setTimeBudget] = useState(DEFAULT_TIME);
@@ -88,7 +86,6 @@ export function Timer({ totalTime, updateTimeEntries }: Props) {
           key={timeLeft}
           status={status}
         />
-        <TotalsDisplay totalTime={totalTime} />
       </div>
       <ActionButtons start={start} pause={pause} stop={stop} status={status} />
     </div>

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -2,3 +2,31 @@ export function notify() {
   const permissionGranted = window.Notification?.permission === "granted";
   if (permissionGranted) new Notification("Timer Session Ended");
 }
+
+export function getTodaysEarliestEntryIndex(
+  entries: { start: number; end: number; text: string }[]
+) {
+  const today = new Date();
+  const timestamp = today.setHours(0, 0, 0, 0);
+  let low = 0;
+  let high = entries.length - 1;
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    if (entries[mid].end > timestamp) {
+      high = mid - 1;
+    } else {
+      low = mid + 1;
+    }
+  }
+  return low;
+}
+
+export function getTodaysTotalTime(
+  entries: { start: number; end: number; text: string }[]
+) {
+  const idx = getTodaysEarliestEntryIndex(entries);
+  const totalInMS = entries
+    .slice(idx)
+    .reduce((acc, entry) => acc + entry.end - entry.start, 0);
+  return totalInMS / 1000;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
 


### PR DESCRIPTION
- track and persist time entries
- render basic time entries
- add basic styles to time entries
- fix: calculate total time spent today
- only render today's entries
- move total time display to entries section
- implement time entry comment component
- fix: ts lib types and const obj references with state setters
- render time entry's text
